### PR TITLE
add: start and stop altbeacon foreground service

### DIFF
--- a/beacon_scanner_android/android/src/main/kotlin/com/lukangagames/plugins/beaconscanner/BeaconScannerPlugin.kt
+++ b/beacon_scanner_android/android/src/main/kotlin/com/lukangagames/plugins/beaconscanner/BeaconScannerPlugin.kt
@@ -1,5 +1,15 @@
 package com.lukangagames.plugins.beaconscanner
 
+import android.app.Application
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.TaskStackBuilder
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import android.util.Log
+
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
@@ -20,6 +30,7 @@ import io.flutter.plugin.common.PluginRegistry.ActivityResultListener
 import io.flutter.plugin.common.PluginRegistry.RequestPermissionsResultListener
 import org.altbeacon.beacon.BeaconManager
 import org.altbeacon.beacon.BeaconParser
+import org.altbeacon.beacon.Settings
 
 class BeaconScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, RequestPermissionsResultListener,
     ActivityResultListener {
@@ -53,6 +64,9 @@ class BeaconScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, Req
     override fun onAttachedToEngine(binding: FlutterPluginBinding) {
         flutterPluginBinding = binding
         setupPluginMethods(binding.binaryMessenger, binding.applicationContext)
+        beaconManager?.adjustSettings(Settings(
+            longScanForcingEnabled = true
+        ))
     }
 
     private fun setupPluginMethods(messenger: BinaryMessenger, context: Context) {
@@ -128,6 +142,7 @@ class BeaconScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, Req
             "initialize" -> {
                 if (beaconManager != null && !beaconManager!!.isBound(beaconScanner!!.beaconConsumer)) {
                     flutterResult = result
+                    startForegroundService()
                     beaconManager!!.bind(beaconScanner!!.beaconConsumer)
                 } else {
                     result.success(true)
@@ -145,6 +160,7 @@ class BeaconScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, Req
                     if (beaconManager!!.isBound(beaconScanner!!.beaconConsumer)) {
                         beaconManager!!.unbind(beaconScanner!!.beaconConsumer)
                     }
+                    stopForegroundService()
                 }
                 result.success(true)
             }
@@ -274,6 +290,7 @@ class BeaconScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, Req
         }
         if (beaconManager != null && !beaconManager!!.isBound(beaconScanner!!.beaconConsumer)) {
             flutterResult = result
+            startForegroundService()
             beaconManager!!.bind(beaconScanner!!.beaconConsumer)
             return
         }
@@ -288,6 +305,40 @@ class BeaconScannerPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, Req
         override fun onCancel(arguments: Any?) {
             eventSinkLocationAuthorizationStatus = null
         }
+    }
+
+    private fun startForegroundService() {
+        try {
+            val context = flutterPluginBinding!!.applicationContext
+            val builder = NotificationCompat.Builder(
+                context,
+                "beacon_scan_channel"
+            )
+                .setSmallIcon(android.R.drawable.stat_sys_data_bluetooth)
+                .setContentTitle("Scanning for Beacons")
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val channel: NotificationChannel = NotificationChannel(
+                    "BeaconScanner channel",
+                    "Beacon scanner", NotificationManager.IMPORTANCE_HIGH
+                )
+                channel.setDescription("Scanning for iBeacons in background")
+                val notificationManager: NotificationManager =
+                    context.getSystemService(
+                        Context.NOTIFICATION_SERVICE
+                    ) as NotificationManager
+                notificationManager.createNotificationChannel(channel)
+                builder.setChannelId(channel.getId())
+            }
+            beaconManager?.enableForegroundServiceScanning(builder.build(), 456)
+            beaconManager?.setEnableScheduledScanJobs(false)
+        } catch (ignored: RuntimeException) {
+            Log.w("BeaconsPlugin", ignored.toString());
+        }
+    }
+
+    private fun stopForegroundService() {
+        beaconManager?.disableForegroundServiceScanning()
     }
 
     // region ACTIVITY CALLBACK

--- a/beacon_scanner_android/android/src/main/kotlin/com/lukangagames/plugins/beaconscanner/BeaconScannerService.kt
+++ b/beacon_scanner_android/android/src/main/kotlin/com/lukangagames/plugins/beaconscanner/BeaconScannerService.kt
@@ -190,6 +190,10 @@ internal class BeaconScannerService(plugin: BeaconScannerPlugin, context: Contex
 
     private val monitorNotifier: MonitorNotifier = object : MonitorNotifier {
         override fun didEnterRegion(region: Region) {
+            if (plugin.getBeaconManager()!!.foregroundServiceStartFailed()) {
+                plugin.getBeaconManager()!!.retryForegroundServiceScanning()
+            }
+
             if (eventSinkMonitoring != null) {
                 val map: MutableMap<String, Any?> = HashMap()
                 map["event"] = "didEnterRegion"
@@ -199,6 +203,9 @@ internal class BeaconScannerService(plugin: BeaconScannerPlugin, context: Contex
         }
 
         override fun didExitRegion(region: Region) {
+            if (plugin.getBeaconManager()!!.foregroundServiceStartFailed()) {
+                plugin.getBeaconManager()!!.retryForegroundServiceScanning()
+            }
             if (eventSinkMonitoring != null) {
                 val map: MutableMap<String, Any?> = HashMap()
                 map["event"] = "didExitRegion"


### PR DESCRIPTION
Added enableForegroundServiceScanning() and disableForegroundServiceScanning() calls to BeaconScannerPlugin initialize() and close() respectively to allow the scans in headless mode